### PR TITLE
Remove duplicate HTTP server startup call

### DIFF
--- a/main.py
+++ b/main.py
@@ -1668,9 +1668,4 @@ def main():
         logger.info("Bot arrêté proprement")
 
 if __name__ == '__main__':
-    # Démarrer le serveur HTTP dans un thread séparé
-    http_thread = threading.Thread(target=start_http_server, daemon=True)
-    http_thread.start()
-    
-    # Lancer la fonction principale du bot
     main()


### PR DESCRIPTION
## Summary
- Start the HTTP server only from `main()` to avoid double startup
- Simplify `__main__` block to call `main()` directly

## Testing
- `TELEGRAM_TOKEN=dummy timeout 15s python main.py`

------
https://chatgpt.com/codex/tasks/task_e_6896490cb99c8324b96759e6b8c8ef54